### PR TITLE
Rename OnnxTextModelScorer to OnnxTextEmbeddingScorer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ This document walks through every component in the solution and traces the data 
 │                                                                              │
 │  // Composable pipeline (new):                                               │
 │  var pipeline = mlContext.Transforms.TokenizeText(tokenizerOpts)             │
-│      .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))            │
+│      .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))            │
 │      .Append(mlContext.Transforms.PoolEmbedding(poolingOpts));               │
 │                                                                              │
 │  // Convenience API (unchanged):                                             │
@@ -42,7 +42,7 @@ This document walks through every component in the solution and traces the data 
 │             Reusable Foundation (any transformer ONNX model)                  │
 │                                                                              │
 │  ┌────────────────────┐     ┌──────────────────────────────┐                 │
-│  │ TextTokenizer-     │     │ OnnxTextModelScorer-         │                 │
+│  │ TextTokenizer-     │     │ OnnxTextEmbeddingScorer-         │                 │
 │  │ Transformer        │     │ Transformer                  │                 │
 │  │                    │     │                              │                 │
 │  │ Text →             │     │ TokenIds + AttentionMask +   │                 │
@@ -86,7 +86,7 @@ TextTokenizerTransformer:
   │ AttentionMask (VBuffer<long>)       ← NEW: 1=real token, 0=padding
   │ TokenTypeIds (VBuffer<long>)        ← NEW: zeros (segment IDs)
   ▼
-OnnxTextModelScorerTransformer:
+OnnxTextEmbeddingScorerTransformer:
   │ Text (string)                       ← passed through
   │ TokenIds (VBuffer<long>)            ← passed through
   │ AttentionMask (VBuffer<long>)       ← passed through
@@ -144,7 +144,7 @@ Fit(IDataView input)
   ├─ 1. Create TextTokenizerEstimator → Fit → TextTokenizerTransformer
   │     Loads tokenizer via smart resolution (directory/config/vocab file)
   │
-  ├─ 2. Create OnnxTextModelScorerEstimator → Fit → OnnxTextModelScorerTransformer
+  ├─ 2. Create OnnxTextEmbeddingScorerEstimator → Fit → OnnxTextEmbeddingScorerTransformer
   │     Creates InferenceSession, auto-discovers tensor metadata
   │
   ├─ 3. Create EmbeddingPoolingEstimator → Fit → EmbeddingPoolingTransformer

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -180,7 +180,7 @@ var tokenizer = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
 var tokenized = tokenizer.Transform(dataView);
 
 // Step 2: Score with ONNX (task-agnostic)
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = "model.onnx",
     MaxTokenLength = 128,
@@ -215,12 +215,12 @@ The composable architecture makes it easy to add new task-specific transforms th
 ```csharp
 // Future: text classification
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.SoftmaxClassify(classOpts));  // new transform
 
 // Future: named entity recognition
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.DecodeNerEntities(nerOpts));  // new transform
 ```
 
@@ -319,7 +319,7 @@ This would give full `mlContext.Model.Save()` / `mlContext.Model.Load()` support
 
 GPU (CUDA) inference is now supported. The library references `Microsoft.ML.OnnxRuntime.Managed` (managed API only, no native binaries). Consuming applications choose their execution provider by referencing the appropriate native package (`Microsoft.ML.OnnxRuntime` for CPU, `Microsoft.ML.OnnxRuntime.Gpu` for CUDA).
 
-Both `OnnxTextModelScorerOptions` and `OnnxTextEmbeddingOptions` expose `GpuDeviceId` and `FallbackToCpu` properties. The resolution order follows ML.NET convention:
+Both `OnnxTextEmbeddingScorerOptions` and `OnnxTextEmbeddingOptions` expose `GpuDeviceId` and `FallbackToCpu` properties. The resolution order follows ML.NET convention:
 
 1. Per-estimator `options.GpuDeviceId` (explicit override)
 2. `mlContext.GpuDeviceId` (context-level default)
@@ -330,7 +330,7 @@ Both `OnnxTextModelScorerOptions` and `OnnxTextEmbeddingOptions` expose `GpuDevi
 mlContext.GpuDeviceId = 0;
 
 // Or per-estimator override with graceful fallback
-var scorerOptions = new OnnxTextModelScorerOptions
+var scorerOptions = new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = "model.onnx",
     GpuDeviceId = 0,

--- a/proposals/03-embedding-pooling-transform.md
+++ b/proposals/03-embedding-pooling-transform.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Applies pooling and normalization to raw model output to produce a fixed-length embedding vector. This is the **task-specific post-processing step** for embedding generation. It is one of potentially many post-processing transforms that can sit downstream of `OnnxTextModelScorerTransformer`.
+Applies pooling and normalization to raw model output to produce a fixed-length embedding vector. This is the **task-specific post-processing step** for embedding generation. It is one of potentially many post-processing transforms that can sit downstream of `OnnxTextEmbeddingScorerTransformer`.
 
 ## Why a Separate Transform?
 
@@ -114,14 +114,14 @@ public sealed class EmbeddingPoolingEstimator : IEstimator<EmbeddingPoolingTrans
     internal EmbeddingPoolingEstimator(
         MLContext mlContext,
         EmbeddingPoolingOptions options,
-        OnnxTextModelScorerTransformer scorer)
+        OnnxTextEmbeddingScorerTransformer scorer)
         : this(mlContext, ConfigureFromScorer(options, scorer))
     {
     }
 
     private static EmbeddingPoolingOptions ConfigureFromScorer(
         EmbeddingPoolingOptions options,
-        OnnxTextModelScorerTransformer scorer)
+        OnnxTextEmbeddingScorerTransformer scorer)
     {
         // Auto-fill dimensions from scorer metadata
         options.HiddenDim = scorer.HiddenDim;
@@ -535,7 +535,7 @@ All share the same lazy cursor pattern: wrap upstream IDataView, compute per-row
 ## Acceptance Criteria
 
 1. `EmbeddingPoolingEstimator` validates HiddenDim and SequenceLength
-2. Auto-configures from `OnnxTextModelScorerTransformer` metadata when used via facade
+2. Auto-configures from `OnnxTextEmbeddingScorerTransformer` metadata when used via facade
 3. `Fit()` validates that input and attention mask columns exist
 4. `Transform()` returns a wrapping IDataView (no materialization)
 5. Cursor computes pooling per-row on demand (mean, CLS, or max)

--- a/proposals/04-facade-refactor.md
+++ b/proposals/04-facade-refactor.md
@@ -29,7 +29,7 @@ namespace MLNet.Embeddings.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that creates an OnnxTextEmbeddingTransformer.
-/// Internally composes TextTokenizerEstimator → OnnxTextModelScorerEstimator → EmbeddingPoolingEstimator.
+/// Internally composes TextTokenizerEstimator → OnnxTextEmbeddingScorerEstimator → EmbeddingPoolingEstimator.
 /// </summary>
 public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTransformer>
 {
@@ -69,7 +69,7 @@ public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTra
         // We need tokenized data to validate scorer input schema
         var tokenizedData = tokenizerTransformer.Transform(input);
 
-        var scorerOptions = new OnnxTextModelScorerOptions
+        var scorerOptions = new OnnxTextEmbeddingScorerOptions
         {
             ModelPath = _options.ModelPath,
             MaxTokenLength = _options.MaxTokenLength,
@@ -80,7 +80,7 @@ public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTra
             TokenTypeIdsTensorName = _options.TokenTypeIdsName,
             OutputTensorName = _options.OutputTensorName,
         };
-        var scorerEstimator = new OnnxTextModelScorerEstimator(_mlContext, scorerOptions);
+        var scorerEstimator = new OnnxTextEmbeddingScorerEstimator(_mlContext, scorerOptions);
         var scorerTransformer = scorerEstimator.Fit(tokenizedData);
 
         // 3. Create and fit the pooler (auto-configured from scorer metadata)
@@ -130,7 +130,7 @@ public sealed class OnnxTextEmbeddingTransformer : ITransformer, IDisposable
 
     // Internal sub-transforms
     private readonly TextTokenizerTransformer _tokenizer;
-    private readonly OnnxTextModelScorerTransformer _scorer;
+    private readonly OnnxTextEmbeddingScorerTransformer _scorer;
     private readonly EmbeddingPoolingTransformer _pooler;
 
     public bool IsRowToRowMapper => true;
@@ -140,14 +140,14 @@ public sealed class OnnxTextEmbeddingTransformer : ITransformer, IDisposable
 
     // Expose sub-transforms for advanced users
     internal TextTokenizerTransformer Tokenizer => _tokenizer;
-    internal OnnxTextModelScorerTransformer Scorer => _scorer;
+    internal OnnxTextEmbeddingScorerTransformer Scorer => _scorer;
     internal EmbeddingPoolingTransformer Pooler => _pooler;
 
     internal OnnxTextEmbeddingTransformer(
         MLContext mlContext,
         OnnxTextEmbeddingOptions options,
         TextTokenizerTransformer tokenizer,
-        OnnxTextModelScorerTransformer scorer,
+        OnnxTextEmbeddingScorerTransformer scorer,
         EmbeddingPoolingTransformer pooler)
     {
         _mlContext = mlContext;

--- a/proposals/05-meai-integration.md
+++ b/proposals/05-meai-integration.md
@@ -270,11 +270,11 @@ public static class MLContextExtensions
         return new TextTokenizerEstimator(catalog.GetMLContext(), options);
     }
 
-    public static OnnxTextModelScorerEstimator ScoreOnnxTextModel(
+    public static OnnxTextEmbeddingScorerEstimator ScoreOnnxTextEmbedding(
         this TransformsCatalog catalog,
-        OnnxTextModelScorerOptions options)
+        OnnxTextEmbeddingScorerOptions options)
     {
-        return new OnnxTextModelScorerEstimator(catalog.GetMLContext(), options);
+        return new OnnxTextEmbeddingScorerEstimator(catalog.GetMLContext(), options);
     }
 
     public static EmbeddingPoolingEstimator PoolEmbedding(

--- a/proposals/06-post-modularization-samples.md
+++ b/proposals/06-post-modularization-samples.md
@@ -4,7 +4,7 @@
 
 After the modular transform pipeline (proposals 01–05) merges, add samples that showcase patterns **only possible** with the composable architecture. These demonstrate the value of modularization and serve as acceptance tests for the new transforms.
 
-**Dependency:** Proposals 01–05 must be implemented first. These samples use `TextTokenizerEstimator`, `OnnxTextModelScorerEstimator`, `EmbeddingPoolingEstimator`, and `EmbeddingGeneratorEstimator` directly.
+**Dependency:** Proposals 01–05 must be implemented first. These samples use `TextTokenizerEstimator`, `OnnxTextEmbeddingScorerEstimator`, `EmbeddingPoolingEstimator`, and `EmbeddingGeneratorEstimator` directly.
 
 ## Samples
 
@@ -15,7 +15,7 @@ After the modular transform pipeline (proposals 01–05) merges, add samples tha
 **Model:** all-MiniLM-L6-v2 (reuse from BasicUsage — same model files).
 
 **Pattern demonstrated:**
-- Build a pipeline with explicit `TokenizeText → ScoreOnnxTextModel → PoolEmbedding` steps
+- Build a pipeline with explicit `TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding` steps
 - Run the tokenizer + scorer once, then apply three different pooling transforms (Mean, CLS, Max) to the same scored output
 - Compare cosine similarity rankings across the three strategies
 - Show how results differ: CLS tends to weight the [CLS] token's representation, Mean averages all tokens, Max takes the maximum activation per dimension
@@ -57,7 +57,7 @@ var tokenizer = tokenizerEstimator.Fit(dataView);
 var tokenized = tokenizer.Transform(dataView);
 
 // Step 2: Score with ONNX (shared across all pooling strategies)
-var scorerEstimator = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorerEstimator = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 128,
@@ -190,7 +190,7 @@ using (var cursor = tokenized.GetRowCursor(tokenized.Schema))
 
 // Step 2: Score
 Console.WriteLine("=== Step 2: ONNX Scoring ===\n");
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 32,
@@ -385,7 +385,7 @@ These samples should be implemented **after** all of proposals 01–05 are merge
 | Proposal | What it provides | Which sample uses it |
 |----------|-----------------|---------------------|
 | [01-text-tokenizer-transform.md](01-text-tokenizer-transform.md) | `TextTokenizerEstimator` | B1, B2 |
-| [02-onnx-text-model-scorer-transform.md](02-onnx-text-model-scorer-transform.md) | `OnnxTextModelScorerEstimator` | B1, B2 |
+| [02-onnx-text-embedding-scorer-transform.md](02-onnx-text-embedding-scorer-transform.md) | `OnnxTextEmbeddingScorerEstimator` | B1, B2 |
 | [03-embedding-pooling-transform.md](03-embedding-pooling-transform.md) | `EmbeddingPoolingEstimator` | B1, B2 |
 | [04-facade-refactor.md](04-facade-refactor.md) | Facade still works | B3 (creates transformer via facade) |
 | [05-meai-integration.md](05-meai-integration.md) | `EmbeddingGeneratorEstimator` | B3 |
@@ -398,6 +398,6 @@ However, if a future text classification sample is added, it would follow the sa
 
 ```csharp
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.SoftmaxClassify(classificationOpts));  // future transform
 ```

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -7,7 +7,7 @@ Decompose `OnnxTextEmbeddingTransformer` into three composable ML.NET transforms
 | Transform | Responsibility | Reusability |
 |-----------|---------------|-------------|
 | `TextTokenizerTransformer` | Text → token IDs + attention mask | Any transformer model |
-| `OnnxTextModelScorerTransformer` | Token columns → raw ONNX output | Any transformer ONNX model |
+| `OnnxTextEmbeddingScorerTransformer` | Token columns → raw ONNX output | Any transformer ONNX model |
 | `EmbeddingPoolingTransformer` | Raw output → pooled embedding | Embedding generation |
 
 The existing `OnnxTextEmbeddingEstimator` becomes a convenience facade that chains all three, preserving the current API.
@@ -27,7 +27,7 @@ See [architecture.md](architecture.md) for the full component diagram and data f
 ## Detailed Specifications
 
 - [01-text-tokenizer-transform.md](01-text-tokenizer-transform.md) — TextTokenizerEstimator / TextTokenizerTransformer
-- [02-onnx-text-model-scorer-transform.md](02-onnx-text-model-scorer-transform.md) — OnnxTextModelScorerEstimator / OnnxTextModelScorerTransformer
+- [02-onnx-text-embedding-scorer-transform.md](02-onnx-text-embedding-scorer-transform.md) — OnnxTextEmbeddingScorerEstimator / OnnxTextEmbeddingScorerTransformer
 - [03-embedding-pooling-transform.md](03-embedding-pooling-transform.md) — EmbeddingPoolingEstimator / EmbeddingPoolingTransformer
 - [04-facade-refactor.md](04-facade-refactor.md) — OnnxTextEmbeddingEstimator / OnnxTextEmbeddingTransformer refactoring
 - [05-meai-integration.md](05-meai-integration.md) — OnnxEmbeddingGenerator and IEmbeddingGenerator-backed transform

--- a/proposals/architecture.md
+++ b/proposals/architecture.md
@@ -8,7 +8,7 @@
 │                                                                              │
 │  // Composable pipeline (new):                                               │
 │  var pipeline = mlContext.Transforms.TokenizeText(tokenizerOpts)             │
-│      .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))            │
+│      .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))            │
 │      .Append(mlContext.Transforms.PoolEmbedding(poolingOpts));               │
 │                                                                              │
 │  // Convenience API (unchanged):                                             │
@@ -40,7 +40,7 @@
 │             Reusable Foundation (any transformer ONNX model)                  │
 │                                                                              │
 │  ┌────────────────────┐     ┌──────────────────────────────┐                 │
-│  │ TextTokenizer-     │     │ OnnxTextModelScorer-         │                 │
+│  │ TextTokenizer-     │     │ OnnxTextEmbeddingScorer-         │                 │
 │  │ Transformer        │     │ Transformer                  │                 │
 │  │                    │     │                              │                 │
 │  │ Text →             │     │ TokenIds + AttentionMask +   │                 │
@@ -83,7 +83,7 @@ TextTokenizerTransformer:
   │ AttentionMask (VBuffer<long>)       ← NEW: 1=real token, 0=padding
   │ TokenTypeIds (VBuffer<long>)        ← NEW: zeros (or segment IDs for text pairs)
   ▼
-OnnxTextModelScorerTransformer:
+OnnxTextEmbeddingScorerTransformer:
   │ Text (string)                       ← passed through
   │ TokenIds (VBuffer<long>)            ← passed through
   │ AttentionMask (VBuffer<long>)       ← passed through

--- a/proposals/future-tasks.md
+++ b/proposals/future-tasks.md
@@ -8,7 +8,7 @@ The three-way split creates a reusable foundation for ANY transformer-based ONNX
                     TextTokenizerTransformer
                             │
                             ▼
-                 OnnxTextModelScorerTransformer
+                 OnnxTextEmbeddingScorerTransformer
                             │
             ┌───────────────┼───────────────────────────┐
             │               │               │           │
@@ -48,7 +48,7 @@ public class SoftmaxClassificationOptions
 
 ```csharp
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.SoftmaxClassify(new SoftmaxClassificationOptions
     {
         Labels = ["negative", "neutral", "positive"]
@@ -99,7 +99,7 @@ public class NerDecodingOptions
 
 ```csharp
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.DecodeNer(nerOpts));
 ```
 
@@ -135,7 +135,7 @@ public class SigmoidScorerOptions
 
 ```csharp
 var pipeline = mlContext.Transforms.TokenizeTextPair(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.SigmoidScore(sigmoidOpts));
 ```
 
@@ -179,7 +179,7 @@ Same as cross-encoder similarity, but used in a retrieval context:
 ```csharp
 // Score all query-document pairs
 var pipeline = mlContext.Transforms.TokenizeTextPair(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.SigmoidScore(sigmoidOpts));
 
 // Sort by score descending
@@ -208,7 +208,7 @@ These would be added to `TextTokenizerTransformer` as optional capabilities, not
 | Multi-output tensor support | QA (start_logits + end_logits) | Medium |
 | Dynamic output column names | Tasks with multiple outputs | Low |
 
-Currently the scorer outputs a single tensor. QA models often have two output tensors. This could be handled by allowing multiple output column names in `OnnxTextModelScorerOptions`.
+Currently the scorer outputs a single tensor. QA models often have two output tensors. This could be handled by allowing multiple output column names in `OnnxTextEmbeddingScorerOptions`.
 
 ## Implementation Priority
 

--- a/proposals/implementation-plan.md
+++ b/proposals/implementation-plan.md
@@ -76,27 +76,27 @@ build-test
 
 ---
 
-## Task 2: Create OnnxTextModelScorerEstimator + OnnxTextModelScorerTransformer
+## Task 2: Create OnnxTextEmbeddingScorerEstimator + OnnxTextEmbeddingScorerTransformer
 
 **ID:** `onnx-scorer-transform`
 **Dependencies:** `tokenizer-transform`
-**Spec:** [02-onnx-text-model-scorer-transform.md](02-onnx-text-model-scorer-transform.md)
+**Spec:** [02-onnx-text-embedding-scorer-transform.md](02-onnx-text-embedding-scorer-transform.md)
 
 ### Files to Create
 | File | Lines (est.) |
 |------|-------------|
-| `src/MLNet.Embeddings.Onnx/OnnxTextModelScorerEstimator.cs` | ~140 |
-| `src/MLNet.Embeddings.Onnx/OnnxTextModelScorerTransformer.cs` | ~450 (includes ScorerDataView + ScorerCursor with lookahead batching) |
+| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingScorerEstimator.cs` | ~140 |
+| `src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingScorerTransformer.cs` | ~450 (includes ScorerDataView + ScorerCursor with lookahead batching) |
 
 ### Code to Extract From
-- `OnnxTextEmbeddingEstimator.DiscoverModelMetadata()` → `OnnxTextModelScorerEstimator.DiscoverModelMetadata()`
+- `OnnxTextEmbeddingEstimator.DiscoverModelMetadata()` → `OnnxTextEmbeddingScorerEstimator.DiscoverModelMetadata()`
 - `OnnxTextEmbeddingEstimator.FindTensorName()` / `TryFindTensorName()` → same methods on scorer estimator
 - `OnnxTextEmbeddingTransformer.ProcessBatch()` lines 156-189 → `RunOnnxBatch()` shared by cursor and direct face
 
 ### Types to Create
-- `OnnxTextModelScorerOptions` — options class
-- `OnnxTextModelScorerEstimator` — IEstimator<OnnxTextModelScorerTransformer>
-- `OnnxTextModelScorerTransformer` — ITransformer, IDisposable
+- `OnnxTextEmbeddingScorerOptions` — options class
+- `OnnxTextEmbeddingScorerEstimator` — IEstimator<OnnxTextEmbeddingScorerTransformer>
+- `OnnxTextEmbeddingScorerTransformer` — ITransformer, IDisposable
 - `ScorerDataView` — wrapping IDataView (lazy, no materialization)
 - `ScorerCursor` — lookahead batching cursor (reads N rows, runs batch ONNX, serves one at a time)
 - `OnnxModelMetadata` — internal record for discovered tensor metadata
@@ -171,7 +171,7 @@ build-test
 ### What Changes
 - `Fit()` creates and chains TokenizerEstimator → ScorerEstimator → PoolingEstimator
 - `GetOutputSchema()` delegates through the chain
-- `DiscoverModelMetadata()` moves to `OnnxTextModelScorerEstimator`
+- `DiscoverModelMetadata()` moves to `OnnxTextEmbeddingScorerEstimator`
 - `LoadTokenizer()` moves to `TextTokenizerEstimator`
 - `FindTensorName()` / `TryFindTensorName()` move to scorer estimator
 
@@ -242,7 +242,7 @@ build-test
 
 ### New Extension Methods
 - `mlContext.Transforms.TokenizeText(options)` → `TextTokenizerEstimator`
-- `mlContext.Transforms.ScoreOnnxTextModel(options)` → `OnnxTextModelScorerEstimator`
+- `mlContext.Transforms.ScoreOnnxTextEmbedding(options)` → `OnnxTextEmbeddingScorerEstimator`
 - `mlContext.Transforms.PoolEmbedding(options)` → `EmbeddingPoolingEstimator`
 
 ### Acceptance Criteria
@@ -329,7 +329,7 @@ Add a section demonstrating the composable pipeline alongside existing convenien
 Console.WriteLine("5. Composable Pipeline");
 
 var compPipeline = mlContext.Transforms.TokenizeText(new TextTokenizerOptions { ... })
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions { ... }))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions { ... }))
     .Append(mlContext.Transforms.PoolEmbedding(new EmbeddingPoolingOptions { ... }));
 
 var compChain = compPipeline.Fit(dataView);

--- a/proposals/migration-to-mlnet.md
+++ b/proposals/migration-to-mlnet.md
@@ -63,13 +63,13 @@ TokenizerCursor : DataViewRowCursor        │   ... reconstruct transformer
 
 **What carries over:** `Tokenize()` (direct face), `LoadTokenizer()`, `TokenizedBatch`, all tokenization math.
 
-### OnnxTextModelScorerTransformer
+### OnnxTextEmbeddingScorerTransformer
 
 ```
 BEFORE (Approach C):                        AFTER (Approach D):
 ─────────────────────                       ─────────────────────
 
-OnnxTextModelScorerTransformer : ITransformer  OnnxTextModelScorerTransformer : RowToRowTransformerBase
+OnnxTextEmbeddingScorerTransformer : ITransformer  OnnxTextEmbeddingScorerTransformer : RowToRowTransformerBase
 ├─ Transform() → returns ScorerDataView        ├─ MakeRowMapper() → returns Mapper
 ├─ RunOnnxBatch() (shared inference logic)     ├─ RunOnnxBatch() (unchanged — shared logic)
 ├─ Score() (direct face)                       ├─ Score() (direct face, unchanged)
@@ -219,7 +219,7 @@ Each transform needs `[LoadableClass]` registrations for the ML.NET loader disco
     TextTokenizerTransformer.UserName,
     TextTokenizerTransformer.LoaderSignature)]
 
-// ... similar for OnnxTextModelScorerTransformer, EmbeddingPoolingTransformer
+// ... similar for OnnxTextEmbeddingScorerTransformer, EmbeddingPoolingTransformer
 ```
 
 ## What the Prototype Validates

--- a/proposals/tradeoffs.md
+++ b/proposals/tradeoffs.md
@@ -8,17 +8,17 @@ Users can build custom pipelines by mixing and matching transforms:
 ```csharp
 // Standard embedding pipeline
 var pipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.PoolEmbedding(poolOpts));
 
 // Same tokenizer + scorer, different pooling
 var clsPipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.PoolEmbedding(clsPoolOpts));
 
 // Same tokenizer + scorer, but for classification (future)
 var classifyPipeline = mlContext.Transforms.TokenizeText(tokOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.SoftmaxClassify(classifyOpts));
 ```
 
@@ -107,7 +107,7 @@ Three options classes means three places where column names must agree:
 ```csharp
 // If these don't match, you get a runtime error:
 var tokOpts = new TextTokenizerOptions { TokenIdsColumnName = "TokenIds" };
-var scorerOpts = new OnnxTextModelScorerOptions { TokenIdsColumnName = "InputIds" }; // ← mismatch!
+var scorerOpts = new OnnxTextEmbeddingScorerOptions { TokenIdsColumnName = "InputIds" }; // ← mismatch!
 ```
 
 **Mitigation:** Default column names are consistent across all three transforms (`"TokenIds"`, `"AttentionMask"`, `"TokenTypeIds"`, `"RawOutput"`, `"Embedding"`). Mismatches only occur if the user explicitly overrides names inconsistently. The facade eliminates this entirely by wiring up column names internally.

--- a/samples/BasicUsage/Program.cs
+++ b/samples/BasicUsage/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics.Tensors;
+using System.Numerics.Tensors;
 using Microsoft.Extensions.AI;
 using Microsoft.ML;
 using MLNet.Embeddings.Onnx;
@@ -140,7 +140,7 @@ var tokenizerEstimator = mlContext.Transforms.TokenizeText(new TextTokenizerOpti
 var tokenizerTransformer = tokenizerEstimator.Fit(dataView);
 var tokenizedData = tokenizerTransformer.Transform(dataView);
 
-var scorerEstimator = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorerEstimator = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 128,
@@ -193,7 +193,7 @@ var chainedPipeline = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
         InputColumnName = "Text",
         MaxTokenLength = 128
     })
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
     {
         ModelPath = modelPath,
         MaxTokenLength = 128,

--- a/samples/BasicUsage/README.md
+++ b/samples/BasicUsage/README.md
@@ -18,7 +18,7 @@ End-to-end demo of the **all-MiniLM-L6-v2** embedding model using all API surfac
 2. **Cosine Similarity** — Pairwise similarity between embedded texts using `TensorPrimitives.CosineSimilarity`
 3. **Save/Load Round-Trip** — Serialize to `.mlnet` zip, reload, and verify identical embeddings
 4. **MEAI `IEmbeddingGenerator`** — Use the model through Microsoft.Extensions.AI's provider-agnostic interface
-5. **Composable Pipeline (step-by-step)** — Explicit `TokenizeText → ScoreOnnxTextModel → PoolEmbedding` with individual transform inspection
+5. **Composable Pipeline (step-by-step)** — Explicit `TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding` with individual transform inspection
 6. **Chained Estimator Pipeline (`.Append`)** — Idiomatic ML.NET pattern chaining estimators, then `Fit + Transform` the whole pipeline at once
 
 ## Download Model Files
@@ -54,7 +54,7 @@ dotnet run
 ```csharp
 // Each step is a separate, inspectable transform
 var tokenizer = mlContext.Transforms.TokenizeText(tokenizerOpts).Fit(dataView);
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(scorerOpts).Fit(tokenized);
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts).Fit(tokenized);
 var pooler = mlContext.Transforms.PoolEmbedding(poolingOpts).Fit(scored);
 
 // Inspect intermediate state
@@ -65,7 +65,7 @@ Console.WriteLine($"Hidden dim: {scorer.HiddenDim}");
 
 ```csharp
 var pipeline = mlContext.Transforms.TokenizeText(tokenizerOpts)
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(scorerOpts))
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts))
     .Append(mlContext.Transforms.PoolEmbedding(poolingOpts));
 var model = pipeline.Fit(dataView);
 ```

--- a/samples/BgeSmallEmbedding/Program.cs
+++ b/samples/BgeSmallEmbedding/Program.cs
@@ -21,7 +21,7 @@ var sampleData = new[]
 
 var dataView = mlContext.Data.LoadFromEnumerable(sampleData);
 
-// --- 1. Composable Pipeline: TokenizeText → ScoreOnnxTextModel → PoolEmbedding ---
+// --- 1. Composable Pipeline: TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding ---
 Console.WriteLine("1. Composable Modular Pipeline");
 Console.WriteLine(new string('-', 40));
 
@@ -35,7 +35,7 @@ var tokenizer = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
 var tokenized = tokenizer.Transform(dataView);
 
 // Step 2: Score with ONNX
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 128,
@@ -120,7 +120,7 @@ var chainedPipeline = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
         InputColumnName = "Text",
         MaxTokenLength = 128
     })
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
     {
         ModelPath = modelPath,
         MaxTokenLength = 128,

--- a/samples/BgeSmallEmbedding/README.md
+++ b/samples/BgeSmallEmbedding/README.md
@@ -14,7 +14,7 @@ Demonstrates [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v
 
 ## What This Sample Shows
 
-1. **Composable Modular Pipeline** — Explicit `TokenizeText → ScoreOnnxTextModel → PoolEmbedding` steps using directory-based tokenizer auto-detection
+1. **Composable Modular Pipeline** — Explicit `TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding` steps using directory-based tokenizer auto-detection
 2. **Query prefix for retrieval** — BGE models recommend prepending `"Represent this sentence: "` to queries when doing retrieval against a passage corpus. The sample compares similarity scores with and without the prefix to show its effect
 3. **Chained Estimator Pipeline (`.Append`)** — Idiomatic ML.NET pattern with all three transforms chained
 4. **Convenience Facade** — `OnnxTextEmbeddingEstimator` as a single-shot alternative, verified to produce identical results
@@ -64,7 +64,7 @@ This sample demonstrates the modular pipeline where each step is a separate, ins
 ```csharp
 // Each transform can be inspected and reused independently
 var tokenizer = mlContext.Transforms.TokenizeText(tokenizerOpts).Fit(dataView);
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(scorerOpts).Fit(tokenized);
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts).Fit(tokenized);
 var pooler = mlContext.Transforms.PoolEmbedding(poolingOpts).Fit(scored);
 
 // Reuse the fitted pipeline for multiple embedding calls

--- a/samples/ComposablePoolingComparison/Program.cs
+++ b/samples/ComposablePoolingComparison/Program.cs
@@ -33,7 +33,7 @@ var tokenized = tokenizer.Transform(dataView);
 
 // Step 2: Score with ONNX (shared across all pooling strategies)
 Console.WriteLine("Step 2: ONNX scoring (shared)...");
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 128,

--- a/samples/E5SmallEmbedding/Program.cs
+++ b/samples/E5SmallEmbedding/Program.cs
@@ -21,7 +21,7 @@ var sampleData = new[]
 
 var dataView = mlContext.Data.LoadFromEnumerable(sampleData);
 
-// --- 1. Composable Pipeline: TokenizeText → ScoreOnnxTextModel → PoolEmbedding ---
+// --- 1. Composable Pipeline: TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding ---
 Console.WriteLine("1. Composable Modular Pipeline");
 Console.WriteLine(new string('-', 40));
 
@@ -35,7 +35,7 @@ var tokenizer = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
 var tokenized = tokenizer.Transform(dataView);
 
 // Step 2: Score with ONNX
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 128,
@@ -127,7 +127,7 @@ var chainedPipeline = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
         InputColumnName = "Text",
         MaxTokenLength = 128
     })
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
     {
         ModelPath = modelPath,
         MaxTokenLength = 128,

--- a/samples/E5SmallEmbedding/README.md
+++ b/samples/E5SmallEmbedding/README.md
@@ -14,7 +14,7 @@ Demonstrates [intfloat/e5-small-v2](https://huggingface.co/intfloat/e5-small-v2)
 
 ## What This Sample Shows
 
-1. **Composable Modular Pipeline** — Explicit `TokenizeText → ScoreOnnxTextModel → PoolEmbedding` steps using directory-based tokenizer auto-detection
+1. **Composable Modular Pipeline** — Explicit `TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding` steps using directory-based tokenizer auto-detection
 2. **Query/passage prefixes for retrieval** — E5 models use `"query: "` for queries and `"passage: "` for documents. The sample compares similarity scores with and without prefixes to show their effect on retrieval ranking
 3. **Chained Estimator Pipeline (`.Append`)** — Idiomatic ML.NET pattern with all three transforms chained
 4. **Convenience Facade** — `OnnxTextEmbeddingEstimator` as a single-shot alternative, verified to produce identical results
@@ -64,7 +64,7 @@ This sample demonstrates the modular pipeline where each step is a separate, ins
 ```csharp
 // Build the pipeline step by step
 var tokenizer = mlContext.Transforms.TokenizeText(tokenizerOpts).Fit(dataView);
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(scorerOpts).Fit(tokenized);
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts).Fit(tokenized);
 var pooler = mlContext.Transforms.PoolEmbedding(poolingOpts).Fit(scored);
 
 // Inspect model metadata

--- a/samples/GteSmallEmbedding/Program.cs
+++ b/samples/GteSmallEmbedding/Program.cs
@@ -21,7 +21,7 @@ var sampleData = new[]
 
 var dataView = mlContext.Data.LoadFromEnumerable(sampleData);
 
-// --- 1. Composable Pipeline: TokenizeText → ScoreOnnxTextModel → PoolEmbedding ---
+// --- 1. Composable Pipeline: TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding ---
 Console.WriteLine("1. Composable Modular Pipeline");
 Console.WriteLine(new string('-', 40));
 Console.WriteLine("  GTE-Small works well without any prefix.");
@@ -36,7 +36,7 @@ var tokenizer = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
 var tokenized = tokenizer.Transform(dataView);
 
 // Step 2: Score with ONNX
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 128,
@@ -116,7 +116,7 @@ var chainedPipeline = mlContext.Transforms.TokenizeText(new TextTokenizerOptions
         InputColumnName = "Text",
         MaxTokenLength = 128
     })
-    .Append(mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+    .Append(mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
     {
         ModelPath = modelPath,
         MaxTokenLength = 128,

--- a/samples/GteSmallEmbedding/README.md
+++ b/samples/GteSmallEmbedding/README.md
@@ -14,7 +14,7 @@ Demonstrates [thenlper/gte-small](https://huggingface.co/thenlper/gte-small) wit
 
 ## What This Sample Shows
 
-1. **Composable Modular Pipeline** — Explicit `TokenizeText → ScoreOnnxTextModel → PoolEmbedding` steps using directory-based tokenizer auto-detection
+1. **Composable Modular Pipeline** — Explicit `TokenizeText → ScoreOnnxTextEmbedding → PoolEmbedding` steps using directory-based tokenizer auto-detection
 2. **Semantic search demo** — Rank a corpus of documents against multiple queries, showing how the model correctly identifies the most relevant passages without any prefix engineering
 3. **Chained Estimator Pipeline (`.Append`)** — Idiomatic ML.NET pattern with all three transforms chained
 4. **Convenience Facade** — `OnnxTextEmbeddingEstimator` as a single-shot alternative, verified to produce identical results
@@ -61,7 +61,7 @@ This sample uses the modular pipeline with reusable fitted transforms:
 
 ```csharp
 var tokenizer = mlContext.Transforms.TokenizeText(tokenizerOpts).Fit(dataView);
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(scorerOpts).Fit(tokenized);
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(scorerOpts).Fit(tokenized);
 var pooler = mlContext.Transforms.PoolEmbedding(poolingOpts).Fit(scored);
 
 // Helper function reuses the fitted pipeline for multiple batches

--- a/samples/IntermediateInspection/Program.cs
+++ b/samples/IntermediateInspection/Program.cs
@@ -61,7 +61,7 @@ using (var cursor = tokenized.GetRowCursor(tokenized.Schema))
 
 // === Step 2: ONNX Scoring ===
 Console.WriteLine("=== Step 2: ONNX Scoring ===\n");
-var scorer = mlContext.Transforms.ScoreOnnxTextModel(new OnnxTextModelScorerOptions
+var scorer = mlContext.Transforms.ScoreOnnxTextEmbedding(new OnnxTextEmbeddingScorerOptions
 {
     ModelPath = modelPath,
     MaxTokenLength = 32,

--- a/samples/IntermediateInspection/README.md
+++ b/samples/IntermediateInspection/README.md
@@ -19,7 +19,7 @@ After `TokenizeText`, you can inspect:
 
 ### Stage 2: ONNX Scoring
 
-After `ScoreOnnxTextModel`, you can inspect:
+After `ScoreOnnxTextEmbedding`, you can inspect:
 - **Hidden dimension** — The model's internal representation size (384 for MiniLM)
 - **Pre-pooled output** — Whether the model provides a `sentence_embedding` output
 - **Raw output column type** — The shape and data type of the ONNX model output

--- a/src/MLNet.Embeddings.Onnx/MLContextExtensions.cs
+++ b/src/MLNet.Embeddings.Onnx/MLContextExtensions.cs
@@ -41,13 +41,13 @@ public static class MLContextExtensions
     }
 
     /// <summary>
-    /// Creates an ONNX text model scorer transform for transformer-based models.
+    /// Creates an ONNX text embedding scorer transform for transformer-based models.
     /// </summary>
-    public static OnnxTextModelScorerEstimator ScoreOnnxTextModel(
+    public static OnnxTextEmbeddingScorerEstimator ScoreOnnxTextEmbedding(
         this TransformsCatalog catalog,
-        OnnxTextModelScorerOptions options)
+        OnnxTextEmbeddingScorerOptions options)
     {
-        return new OnnxTextModelScorerEstimator(catalog.GetMLContext(), options);
+        return new OnnxTextEmbeddingScorerEstimator(catalog.GetMLContext(), options);
     }
 
     /// <summary>

--- a/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingEstimator.cs
+++ b/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingEstimator.cs
@@ -5,7 +5,7 @@ namespace MLNet.Embeddings.Onnx;
 
 /// <summary>
 /// ML.NET IEstimator that creates an OnnxTextEmbeddingTransformer.
-/// Internally composes TextTokenizerEstimator → OnnxTextModelScorerEstimator → EmbeddingPoolingEstimator.
+/// Internally composes TextTokenizerEstimator → OnnxTextEmbeddingScorerEstimator → EmbeddingPoolingEstimator.
 /// </summary>
 public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTransformer>
 {
@@ -43,7 +43,7 @@ public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTra
         // 2. Create and fit the scorer
         var tokenizedData = tokenizerTransformer.Transform(input);
 
-        var scorerOptions = new OnnxTextModelScorerOptions
+        var scorerOptions = new OnnxTextEmbeddingScorerOptions
         {
             ModelPath = _options.ModelPath,
             MaxTokenLength = _options.MaxTokenLength,
@@ -55,7 +55,7 @@ public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTra
             GpuDeviceId = _options.GpuDeviceId,
             FallbackToCpu = _options.FallbackToCpu,
         };
-        var scorerEstimator = new OnnxTextModelScorerEstimator(_mlContext, scorerOptions);
+        var scorerEstimator = new OnnxTextEmbeddingScorerEstimator(_mlContext, scorerOptions);
         var scorerTransformer = scorerEstimator.Fit(tokenizedData);
 
         // 3. Create and fit the pooler (auto-configured from scorer metadata)
@@ -91,7 +91,7 @@ public sealed class OnnxTextEmbeddingEstimator : IEstimator<OnnxTextEmbeddingTra
 
         // Probe the model to get embedding dimension
         int embeddingDim;
-        var scorerEstimator = new OnnxTextModelScorerEstimator(_mlContext, new OnnxTextModelScorerOptions
+        var scorerEstimator = new OnnxTextEmbeddingScorerEstimator(_mlContext, new OnnxTextEmbeddingScorerOptions
         {
             ModelPath = _options.ModelPath,
             InputIdsTensorName = _options.InputIdsName,

--- a/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingScorerEstimator.cs
+++ b/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingScorerEstimator.cs
@@ -5,10 +5,10 @@ using Microsoft.ML.OnnxRuntime;
 namespace MLNet.Embeddings.Onnx;
 
 /// <summary>
-/// Configuration for the ONNX text model scorer transform.
+/// Configuration for the ONNX text embedding scorer transform.
 /// Runs inference on a transformer-architecture ONNX model (BERT, MiniLM, etc.).
 /// </summary>
-public class OnnxTextModelScorerOptions
+public class OnnxTextEmbeddingScorerOptions
 {
     /// <summary>Path to the ONNX model file.</summary>
     public required string ModelPath { get; set; }
@@ -80,15 +80,15 @@ internal sealed record OnnxModelMetadata(
     int OutputRank);
 
 /// <summary>
-/// ML.NET IEstimator that creates an OnnxTextModelScorerTransformer.
+/// ML.NET IEstimator that creates an OnnxTextEmbeddingScorerTransformer.
 /// Fit() validates the input schema, loads the ONNX model, and auto-discovers tensor metadata.
 /// </summary>
-public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScorerTransformer>
+public sealed class OnnxTextEmbeddingScorerEstimator : IEstimator<OnnxTextEmbeddingScorerTransformer>
 {
     private readonly MLContext _mlContext;
-    private readonly OnnxTextModelScorerOptions _options;
+    private readonly OnnxTextEmbeddingScorerOptions _options;
 
-    public OnnxTextModelScorerEstimator(MLContext mlContext, OnnxTextModelScorerOptions options)
+    public OnnxTextEmbeddingScorerEstimator(MLContext mlContext, OnnxTextEmbeddingScorerOptions options)
     {
         _mlContext = mlContext ?? throw new ArgumentNullException(nameof(mlContext));
         _options = options ?? throw new ArgumentNullException(nameof(options));
@@ -97,7 +97,7 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
             throw new FileNotFoundException($"ONNX model not found: {options.ModelPath}");
     }
 
-    public OnnxTextModelScorerTransformer Fit(IDataView input)
+    public OnnxTextEmbeddingScorerTransformer Fit(IDataView input)
     {
         ValidateColumn(input.Schema, _options.TokenIdsColumnName);
         ValidateColumn(input.Schema, _options.AttentionMaskColumnName);
@@ -107,7 +107,7 @@ public sealed class OnnxTextModelScorerEstimator : IEstimator<OnnxTextModelScore
         var session = CreateInferenceSession();
         var metadata = DiscoverModelMetadata(session);
 
-        return new OnnxTextModelScorerTransformer(_mlContext, _options, session, metadata);
+        return new OnnxTextEmbeddingScorerTransformer(_mlContext, _options, session, metadata);
     }
 
     public SchemaShape GetOutputSchema(SchemaShape inputSchema)

--- a/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingScorerTransformer.cs
+++ b/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingScorerTransformer.cs
@@ -12,16 +12,16 @@ namespace MLNet.Embeddings.Onnx;
 /// The cursor reads ahead BatchSize rows from the upstream tokenizer cursor,
 /// runs a single ONNX session.Run() call, then serves results one at a time.
 /// </summary>
-public sealed class OnnxTextModelScorerTransformer : ITransformer, IDisposable
+public sealed class OnnxTextEmbeddingScorerTransformer : ITransformer, IDisposable
 {
     private readonly MLContext _mlContext;
-    private readonly OnnxTextModelScorerOptions _options;
+    private readonly OnnxTextEmbeddingScorerOptions _options;
     private readonly InferenceSession _session;
     private readonly OnnxModelMetadata _metadata;
 
     public bool IsRowToRowMapper => true;
 
-    internal OnnxTextModelScorerOptions Options => _options;
+    internal OnnxTextEmbeddingScorerOptions Options => _options;
 
     /// <summary>Hidden dimension of the model output.</summary>
     public int HiddenDim => _metadata.HiddenDim;
@@ -31,9 +31,9 @@ public sealed class OnnxTextModelScorerTransformer : ITransformer, IDisposable
 
     internal OnnxModelMetadata Metadata => _metadata;
 
-    internal OnnxTextModelScorerTransformer(
+    internal OnnxTextEmbeddingScorerTransformer(
         MLContext mlContext,
-        OnnxTextModelScorerOptions options,
+        OnnxTextEmbeddingScorerOptions options,
         InferenceSession session,
         OnnxModelMetadata metadata)
     {
@@ -171,13 +171,13 @@ public sealed class OnnxTextModelScorerTransformer : ITransformer, IDisposable
 internal sealed class ScorerDataView : IDataView
 {
     private readonly IDataView _input;
-    private readonly OnnxTextModelScorerTransformer _scorer;
+    private readonly OnnxTextEmbeddingScorerTransformer _scorer;
 
     public DataViewSchema Schema { get; }
     public bool CanShuffle => false;
     public long? GetRowCount() => _input.GetRowCount();
 
-    internal ScorerDataView(IDataView input, OnnxTextModelScorerTransformer scorer)
+    internal ScorerDataView(IDataView input, OnnxTextEmbeddingScorerTransformer scorer)
     {
         _input = input;
         _scorer = scorer;
@@ -237,7 +237,7 @@ internal sealed class ScorerCursor : DataViewRowCursor
 {
     private readonly ScorerDataView _parent;
     private readonly DataViewRowCursor _inputCursor;
-    private readonly OnnxTextModelScorerTransformer _scorer;
+    private readonly OnnxTextEmbeddingScorerTransformer _scorer;
 
     // Lookahead batch state
     private float[][]? _batchResults;
@@ -256,7 +256,7 @@ internal sealed class ScorerCursor : DataViewRowCursor
     internal ScorerCursor(
         ScorerDataView parent,
         DataViewRowCursor inputCursor,
-        OnnxTextModelScorerTransformer scorer)
+        OnnxTextEmbeddingScorerTransformer scorer)
     {
         _parent = parent;
         _inputCursor = inputCursor;

--- a/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingTransformer.cs
+++ b/src/MLNet.Embeddings.Onnx/OnnxTextEmbeddingTransformer.cs
@@ -13,7 +13,7 @@ public sealed class OnnxTextEmbeddingTransformer : ITransformer, IDisposable
     private readonly OnnxTextEmbeddingOptions _options;
 
     private readonly TextTokenizerTransformer _tokenizer;
-    private readonly OnnxTextModelScorerTransformer _scorer;
+    private readonly OnnxTextEmbeddingScorerTransformer _scorer;
     private readonly EmbeddingPoolingTransformer _pooler;
 
     public bool IsRowToRowMapper => true;
@@ -22,14 +22,14 @@ public sealed class OnnxTextEmbeddingTransformer : ITransformer, IDisposable
     public int EmbeddingDimension => _scorer.HiddenDim;
 
     internal TextTokenizerTransformer Tokenizer => _tokenizer;
-    internal OnnxTextModelScorerTransformer Scorer => _scorer;
+    internal OnnxTextEmbeddingScorerTransformer Scorer => _scorer;
     internal EmbeddingPoolingTransformer Pooler => _pooler;
 
     internal OnnxTextEmbeddingTransformer(
         MLContext mlContext,
         OnnxTextEmbeddingOptions options,
         TextTokenizerTransformer tokenizer,
-        OnnxTextModelScorerTransformer scorer,
+        OnnxTextEmbeddingScorerTransformer scorer,
         EmbeddingPoolingTransformer pooler)
     {
         _mlContext = mlContext;


### PR DESCRIPTION
## Summary

Rename `OnnxTextModelScorer*`  `OnnxTextEmbeddingScorer*` throughout the codebase to reflect that this repo is scoped to **embedding models**, not arbitrary text models.

## What changed (32 files)

| Before | After |
|---|---|
| `OnnxTextModelScorerEstimator` | `OnnxTextEmbeddingScorerEstimator` |
| `OnnxTextModelScorerTransformer` | `OnnxTextEmbeddingScorerTransformer` |
| `OnnxTextModelScorerOptions` | `OnnxTextEmbeddingScorerOptions` |
| `ScoreOnnxTextModel()` | `ScoreOnnxTextEmbedding()` |
| `02-onnx-text-model-scorer-transform.md` | `02-onnx-text-embedding-scorer-transform.md` |

## Why

"OnnxTextModelScorer" is semantically vague  "text model" could mean classification, NER, sentiment, etc. In this repo, the scorer exclusively runs embedding models that output hidden states for pooling. The name should match the scope.

The rename aligns the scorer name with the facade (`OnnxTextEmbeddingEstimator`) and makes the API self-documenting.

Full rationale documented in `docs/design-decisions.md` under "Naming: OnnxTextEmbeddingScorer".

## Verified

- [x] Build passes (all 8 projects, zero errors)
- [x] **All 7 samples tested** across 4 different ONNX models (MiniLM, BGE, E5, GTE)
- [x] All cross-validation diffs are `0.00E+000`
- [x] XML doc comments updated
- [x] Proposal file renamed

## Note on the platform repo

The generic `OnnxTextModelScorer` name was preserved in the [mlnet-text-inference-custom-transforms](https://github.com/luisquintanilla/mlnet-text-inference-custom-transforms) fork (created from `main` before this rename) where the scorer will serve multiple tasks beyond embeddings.
